### PR TITLE
fix: phpmd prevent migration from being committed

### DIFF
--- a/src/stubs/phpmd.xml
+++ b/src/stubs/phpmd.xml
@@ -10,6 +10,7 @@
 
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />
+        <exclude name="ShortMethodName" />
     </rule>
 
     <rule ref="rulesets/naming.xml/ShortVariable"
@@ -21,6 +22,18 @@
         <properties>
             <property name="minimum" description="Minimum length for a variable, property or parameter name" value="3"/>
             <property name="exceptions" value="id,q,w,i,j,k,v,e,f,fp" />
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/naming.xml/ShortMethodName"
+          since="0.2"
+          message="Avoid method or function with short names like {0}. Configured minimum length is {1}."
+          class="PHPMD\Rule\Naming\ShortMethodName"
+          externalInfoUrl="https://phpmd.org/rules/naming.html#shortmethodname">
+        <priority>3</priority>
+        <properties>
+            <property name="minimum" description="Minimum length for a method or function name" value="3"/>
+            <property name="exceptions" value="up" />
         </properties>
     </rule>
 


### PR DESCRIPTION
因為預設的 [ShortMethodName](https://phpmd.org/rules/naming.html#shortmethodname) 規則要求至少 3 個字長
導致提交 migration 時會因其 `up()` 被阻擋
所以需要另外拉出來寫規則指定例外

寫法是參照同檔案內其他規則的寫法，如果有哪邊調整的不對請多指教。