### PR TITLE
fix(command): fix command run fix on windows

### DIFF
--- a/src/LintCodeCommand.php
+++ b/src/LintCodeCommand.php
@@ -35,9 +35,8 @@ class LintCodeCommand extends Command
         $bin = $this->option('fix') ? 'phpcbf' : 'phpcs';
         $files = empty($this->argument('files')) ? ['.'] : $this->argument('files');
         $command = "vendor" . DIRECTORY_SEPARATOR . "bin" . DIRECTORY_SEPARATOR . "$bin --standard=";
-        $command .= $this->option('standard') . ' ' . implode(' ', $files);
         exec(
-            $command,
+            $command . $this->option('standard') . ' ' . implode(' ', $files),
             $output,
             $code
         );


### PR DESCRIPTION
Fix error on window when run `php artisan lint:code --fix`
```
'vendor' is not recognized as an internal or external command,
operable program or batch file.
```