### PR TITLE
feat: publish xml when config not exists

### DIFF
--- a/src/LintPublishCommand.php
+++ b/src/LintPublishCommand.php
@@ -30,8 +30,12 @@ class LintPublishCommand extends Command
     {
         $basePath = $this->laravel->basePath();
 
-        File::copy(__DIR__ . '/stubs/phpcs.xml', $basePath . '/phpcs.xml');
-        File::copy(__DIR__ . '/stubs/phpmd.xml', $basePath . '/phpmd.xml');
+        if (!File::exists($basePath . '/phpcs.xml')) {
+            File::copy(__DIR__ . '/stubs/phpcs.xml', $basePath . '/phpcs.xml');
+        }
+        if (!File::exists($basePath . '/phpmd.xml')) {
+            File::copy(__DIR__ . '/stubs/phpmd.xml', $basePath . '/phpmd.xml');
+        }
         if (File::exists($basePath . '/.git/hooks')) {
             File::copy(__DIR__ . '/stubs/git-pre-commit', $basePath . '/.git/hooks/pre-commit');
             File::chmod($basePath . '/.git/hooks/pre-commit', 0755);

--- a/tests/LintPublishCommandTest.php
+++ b/tests/LintPublishCommandTest.php
@@ -25,4 +25,53 @@ class LintPublishCommandTest extends TestCase
         $this->assertFileExists($laravelPath . '/phpmd.xml');
         $this->assertFileExists($laravelPath . '/.git/hooks/pre-commit');
     }
+
+    public function testPhpcsExists()
+    {
+        $laravelPath = __DIR__ . '/../vendor/orchestra/testbench-core/laravel';
+        File::delete($laravelPath . '/phpcs.xml');
+        $this->assertFileDoesNotExist($laravelPath . '/phpcs.xml');
+        File::append($laravelPath . '/phpcs.xml', 'phpcs');
+        $this->assertFileExists($laravelPath . '/phpcs.xml');
+        $this->artisan('lint:publish')->run();
+        $this->assertEquals('phpcs', File::get($laravelPath . '/phpcs.xml'));
+        $this->assertFileExists($laravelPath . '/phpmd.xml');
+        $this->assertFileExists($laravelPath . '/.git/hooks/pre-commit');
+    }
+
+    public function testPhpcsNotExists()
+    {
+        $laravelPath = __DIR__ . '/../vendor/orchestra/testbench-core/laravel';
+        File::delete($laravelPath . '/phpcs.xml');
+        $this->assertFileDoesNotExist($laravelPath . '/phpcs.xml');
+        $this->artisan('lint:publish')->run();
+        $this->assertFileExists($laravelPath . '/phpcs.xml');
+        $this->assertXmlFileEqualsXmlFile(__DIR__ . '/../src/stubs/phpcs.xml', $laravelPath . '/phpcs.xml');
+        $this->assertFileExists($laravelPath . '/phpmd.xml');
+        $this->assertFileExists($laravelPath . '/.git/hooks/pre-commit');
+    }
+
+    public function testPhpmdExists()
+    {
+        $laravelPath = __DIR__ . '/../vendor/orchestra/testbench-core/laravel';
+        File::delete($laravelPath . '/phpmd.xml');
+        $this->assertFileDoesNotExist($laravelPath . '/phpmd.xml');
+        File::append($laravelPath . '/phpmd.xml', 'phpmd');
+        $this->assertFileExists($laravelPath . '/phpmd.xml');
+        $this->artisan('lint:publish')->run();
+        $this->assertEquals('phpmd', File::get($laravelPath . '/phpmd.xml'));
+        $this->assertFileExists($laravelPath . '/phpcs.xml');
+        $this->assertFileExists($laravelPath . '/.git/hooks/pre-commit');
+    }
+    public function testPhpmdNotExists()
+    {
+        $laravelPath = __DIR__ . '/../vendor/orchestra/testbench-core/laravel';
+        File::delete($laravelPath . '/phpmd.xml');
+        $this->assertFileDoesNotExist($laravelPath . '/phpmd.xml');
+        $this->artisan('lint:publish')->run();
+        $this->assertFileExists($laravelPath . '/phpmd.xml');
+        $this->assertXmlFileEqualsXmlFile(__DIR__ . '/../src/stubs/phpmd.xml', $laravelPath . '/phpmd.xml');
+        $this->assertFileExists($laravelPath . '/phpcs.xml');
+        $this->assertFileExists($laravelPath . '/.git/hooks/pre-commit');
+    }
 }


### PR DESCRIPTION
otherwise, the exists config will be overridden.

For example, I had published `phpcs.xml` and changed it. My partner clone and run publish command again for git hook, the edited `phpcs.xml` will be overridden.

To avoid it, should check config whether exists, then decide copy xml or not.